### PR TITLE
chore: update GitHub Actions SHA pins (2026-03-20)

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:
           bun-version: 1.3.9
 
@@ -25,7 +25,7 @@ jobs:
         run: bun run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: build
 


### PR DESCRIPTION
## Summary

定期的な依存関係アップデート（GitHub Actions）。

- `actions/checkout`: v4.2.2 → v6.0.2（Node.jsランタイム更新 + 認証情報の保存方法変更。`ubuntu-latest`では影響なし）
- `oven-sh/setup-bun`: v2.1.2 → v2.1.3（バグ修正・パフォーマンス改善のみ）
- `actions/upload-pages-artifact`: v3.0.1 → v4.0.0（dotfileがartifactから除外される変更。`static/.nojekyll`は存在するが、`actions/deploy-pages`はJekyll処理をバイパスするため影響なし）

※ `oven-sh/setup-bun` v2.2.0は7日間クールダウンによりスキップ（2026-03-14リリース）

## Test plan

- [ ] GitHub Actionsのデプロイワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)