### PR TITLE
fix: typecheckをtsc --noEmitに変更しoxlint-tsgolintを削除

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,6 @@
         "@types/bun": "1.3.9",
         "oxfmt": "0.27.0",
         "oxlint": "1.42.0",
-        "oxlint-tsgolint": "0.11.4",
         "typescript": "5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "lint": "oxlint",
     "format": "oxfmt",
-    "typecheck": "oxlint --type-aware --type-check",
+    "typecheck": "tsc --noEmit",
     "ncu": "ncu --cooldown 7"
   },
   "dependencies": {
@@ -33,7 +33,6 @@
     "@types/bun": "1.3.9",
     "oxfmt": "0.27.0",
     "oxlint": "1.42.0",
-    "oxlint-tsgolint": "0.11.4",
     "typescript": "5.9.3"
   },
   "browserslist": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary
- `oxlint-tsgolint`を削除し、`typecheck`スクリプトを`tsc --noEmit`に変更
- `tsconfig.json`から`@docusaurus/tsconfig`と重複していた冗長な`compilerOptions.baseUrl`を削除

## 背景
`oxlint-tsgolint`がTypeScript 6(typescript-go)前提で動作しており、`@docusaurus/tsconfig`が含む`baseUrl`オプションをTypeScript 6で削除済みとして扱いエラーにしていた。DocusaurusはまだTypeScript 5前提のため、`tsc --noEmit`を使うことで問題を解消する。

## Test plan
- [x] `bun run typecheck` がエラー0件で通ること
- [x] `bun run lint` が引き続き通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)