### PR TITLE
feat: update-dependencies skill の追加と周辺環境の整備

### DIFF
--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: update-dependencies
+description: Update dependencies of side-oripathy (a Docusaurus static site) safely, avoiding build breakage and breaking changes. Inspect npm packages and GitHub Actions with a 7-day cooldown, check vulnerabilities via bun audit and osv-scanner, then triage packages into Batched / Individual and delegate PR creation to sub-agents. Because pushes to main are auto-deployed to GitHub Pages, the build check is mandatory. Use this skill when asked to update dependencies, respond to vulnerabilities, or bump npm packages or GitHub Actions versions.
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Bash(bunx --bun ncu:*)
+  - Bash(bun run --bun ncu:*)
+  - Bash(pinact:*)
+  - Bash(bun audit)
+  - Bash(osv-scanner:*)
+  - Bash(gh:*)
+  - Write
+  - Edit
+  - Bash(git:*)
+  - Bash(bun install:*)
+  - Bash(bun add:*)
+  - Bash(bun info:*)
+  - Bash(bun run:*)
+  - Bash(grep:*)
+  - Bash(head:*)
+  - Bash(jq:*)
+---
+
+update dependencies with following instructions
+
+use `jq` to parse JSON outputs and `grep` to filter for relevant information.
+
+This repository is a Docusaurus static site, and every push to `main` is automatically deployed to GitHub Pages. Therefore **any change that breaks `bun run build` results in a production outage**. Never skip the build step in the validation phase.
+
+## Step 1: Deep Inspection & Security
+
+1. Sync the environment with `bun install --frozen-lockfile`
+
+2. To mitigate supply chain attacks, check for the latest versions released more than 7 days ago. Unless specified otherwise, check across all package managers.
+```
+# npm packages (the `ncu` script in package.json applies `-c 7 -p bun -w` by default)
+bun run --bun ncu
+
+# GitHub Actions
+pinact run --min-age 7
+```
+
+3. Gather security information. Security updates take priority and bypass the 7-day rule in Step 1.2.
+```
+bun audit
+osv-scanner scan source -r .
+```
+
+## Step 2: Triage
+
+For each package detected in Steps 1.2 and 1.3, do the following:
+
+1. Resolve the repository URL with `bun info {package} repository.url`.
+2. Check the tag naming convention (e.g., whether tags are prefixed with `v`) using `gh release list -R {repo} -L 3 --json tagName -q '.[].tagName'`, so that `{from}` and `{to}` can be passed in the correct format to the next command.
+3. Estimate the impact on the project and triage each package into one of two classes using `gh api repos/{repo}/compare/{from}...{to} --jq '.commits[].commit.message' | grep -iE '(^[a-z]+(\([^)]+\))?!:|BREAKING[ _-]?CHANGE|^(deprecate|remove|drop)\b)' | head -30` (this grep detects conventional commit breaking markers and fallback keywords).
+
+Batched: no impact on project code or behavior → processed together in a single PR
+Individual: likely to have impact → processed in a dedicated PR per package
+
+**Do not over-trust SemVer. Even patch updates can contain breaking changes. That said, major updates are unconditionally treated as Individual.**
+
+## Step 3: Orchestrate Sub-Agents
+
+Based on the triage results, delegate update work to sub-agents.
+
+**All PRs, issues, and commit messages must be written in Japanese.**
+
+### Batched updates
+
+Pass the list of Batched packages (identified in Step 2) to a single sub-agent. The sub-agent must not re-triage; it operates on the provided list.
+
+- Work in a single git worktree and produce a single PR.
+- Update packages one at a time, running the following checks after each update:
+  ```
+  bun run --bun typecheck && bun run --bun lint && bun run --bun format && bun run build
+  ```
+  - `build` verifies the Docusaurus static build. It is mandatory because main is auto-deployed.
+  - If `format` (oxfmt) rewrites files, include those rewrites in the same commit.
+- If checks pass, proceed to the next package (one commit per package).
+- If checks fail, do not create a commit for that package. Revert to the pre-update state with `git stash && bun install --frozen-lockfile` and skip the package.
+- Once all packages have been processed, create a PR containing only the packages that passed.
+  - PR body: list of updated packages with before/after versions.
+- On completion, report the list of skipped packages (package name, from/to versions, and a summary of the failure) to the orchestrator.
+
+**The sub-agent must not attempt to fix skipped packages.** Report failures to the orchestrator so they can be re-triaged as Individual and handled with dedicated context.
+
+### Re-triage by the orchestrator
+
+When the Batched sub-agent reports skipped packages, re-triage them as Individual and add them to the Individual updates below.
+
+### Individual updates
+
+Packages classified as Individual (both originally Individual and those promoted from Batched) are processed by a dedicated sub-agent, git worktree, and PR per package.
+
+- Address the following:
+  - Fixes for failing checks (`typecheck` / `lint` / `format` / `build`).
+  - Code improvements that leverage new or improved APIs.
+  - Replacement of deprecated APIs.
+- For major Docusaurus updates, consult the upstream Migration Guide and verify/apply any breaking changes affecting `docusaurus.config.ts` / `sidebars.ts` / `src/theme/` / `src/css/` (plugin API changes, swizzled component signature changes, theme class name renames, etc.).
+- PR body: updated package, before/after versions, affected project code or behavior, summary of changes made, and rationale for any items left unaddressed.
+- If checks still fail after 5 fix attempts (one attempt = one cycle of code change → `bun run --bun typecheck && bun run --bun lint && bun run --bun format && bun run build`), create a GitHub Issue and a Draft PR, then stop.
+  - Title: `[Package Name] from vA to vB`
+  - Body: error details, the upstream change causing the impact, affected project code or behavior, and approaches attempted.
+  - After creating the Issue, create a Draft PR and include a link to the Issue in its description.

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetify.com/docs/devbox/ide_configuration/direnv/
+# for more details

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-.envrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,24 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Docusaurus site for "Side Oripathy", an Arknights × Emoklore TRPG add-on ruleset (Japanese).
 
-## プロジェクト概要
+## Commands
 
-アークナイツ×エモクロアTRPG「サイド・オリパシー」の追加ルールを公開するDocusaurusベースのドキュメントサイト。日本語のTRPGルールブックとキャラクターシートコンバーターを提供している。
-
-## 開発コマンド
+Package manager: bun (v1.3.8).
 
 ```bash
-# パッケージマネージャー: bun (v1.3.8)
-bun install          # 依存関係のインストール
-bun run start        # 開発サーバー起動
-bun run build        # プロダクションビルド（buildディレクトリに出力）
-bun run serve        # ビルド済みサイトのプレビュー
-
-# 品質チェック（oxlint/oxfmtはbunランタイムで実行）
-bun run --bun lint      # oxlintによるリント
-bun run --bun format    # oxfmtによるフォーマット
-bun run --bun typecheck # 型チェック
-bun run --bun ncu       # 依存パッケージのアップデートチェック
+bun run start        # dev server
+bun run build        # production build
+bun run --bun lint       # oxlint
+bun run --bun format     # oxfmt
+bun run --bun typecheck  # tsc --noEmit
+bun run --bun ncu        # dependency updates
 ```
 
-## アーキテクチャ
+## Layout
 
-- **docs/**: Markdownによるルールドキュメント（サイドバーは`sidebars.ts`で自動生成）
-- **src/pages/converter.tsx**: CCFOLIAおよびチャットパレット形式のキャラクターシートを「サイド・オリパシー」用に変換するコンバーター
-- **src/components/**: ドキュメント内で使用するMDXコンポーネント（`Expression`、`Memo`）
+- `docs/` — rule docs (sidebar auto-generated via `sidebars.ts`)
+- `src/pages/converter.tsx` — character sheet converter (CCFOLIA / chat palette)
+- `src/components/` — MDX components (`Expression`, `Memo`)
 
-## デプロイ
-
-mainブランチへのプッシュでGitHub Pagesに自動デプロイされる。
+Pushing to `main` auto-deploys to GitHub Pages.

--- a/devbox.json
+++ b/devbox.json
@@ -2,12 +2,10 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.1/.schema/devbox.schema.json",
   "packages": [
     "bun@1.3.9",
-    "pinact@3.8.0"
+    "pinact@3.8.0",
+    "osv-scanner@2.3.3"
   ],
   "shell": {
-    "init_hook": [
-      "[ -f ~/.env.mcp ] && source ~/.env.mcp"
-    ],
     "scripts": {
       "pinact": [
         "pinact run --min-age 7"

--- a/devbox.lock
+++ b/devbox.lock
@@ -53,6 +53,54 @@
       "last_modified": "2026-04-10T03:55:24Z",
       "resolved": "github:NixOS/nixpkgs/9d29d5f667d7467f98efc31881e824fa586c927e?lastModified=1775793324"
     },
+    "osv-scanner@2.3.3": {
+      "last_modified": "2026-04-16T08:46:55Z",
+      "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b#osv-scanner",
+      "source": "devbox-search",
+      "version": "2.3.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/26f8vzcwhq4aad9ddxbz4pymzz5lh6nx-osv-scanner-2.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/26f8vzcwhq4aad9ddxbz4pymzz5lh6nx-osv-scanner-2.3.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dz891r0gzh2pw288dzj4pw7j590aykji-osv-scanner-2.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dz891r0gzh2pw288dzj4pw7j590aykji-osv-scanner-2.3.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bhd8683zn3kdn2yy689vqaxl9kq05kd6-osv-scanner-2.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bhd8683zn3kdn2yy689vqaxl9kq05kd6-osv-scanner-2.3.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vmzjbq55q6jn6i77i1vni6vd8nish9ak-osv-scanner-2.3.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vmzjbq55q6jn6i77i1vni6vd8nish9ak-osv-scanner-2.3.3"
+        }
+      }
+    },
     "pinact@3.8.0": {
       "last_modified": "2026-03-21T07:29:51Z",
       "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#pinact",


### PR DESCRIPTION
## Summary

- `.claude/skills/update-dependencies/SKILL.md` を新規追加。Docusaurus サイト向けに ncu / pinact の 7 日クールダウン検査、`bun audit` / `osv-scanner` による脆弱性チェック、Batched / Individual 振り分けと sub-agent への PR 委譲までを定義
- main への push が GitHub Pages に自動デプロイされる構成に合わせて `typecheck / lint / format / build` を検証チェーンに組み込み、`build` 検証を必須化
- devbox に `osv-scanner@2.3.3` を追加し、direnv 経由の `.envrc` を追跡対象に。不要な `init_hook` を除去
- CLAUDE.md を簡潔な概要・コマンド・レイアウト構成へ整理

関連 Issue: #76 (テスト戦略の策定とテストコード導入) — 本 PR でスキル側に `bun run --bun test` は入れていない。テスト導入完了後に別途反映する想定。

## Test plan

- [x] `bun install --frozen-lockfile` が通る
- [x] `bun run --bun typecheck && bun run --bun lint && bun run --bun format && bun run build` が通る
- [x] `osv-scanner scan source -r .` が動作する
- [x] `pinact run --min-age 7` が動作する
- [x] `bun run --bun ncu` が動作する
- [x] direnv/devbox shell で開発環境が正しく立ち上がる
- [x] SKILL.md の frontmatter (YAML) が妥当

🤖 Generated with [Claude Code](https://claude.com/claude-code)