### PR TITLE
feat: Claude Code automations を追加（context7・textlintフック・proseレビュアー）

### DIFF
--- a/.claude/agents/ja-prose-reviewer.md
+++ b/.claude/agents/ja-prose-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: ja-prose-reviewer
+description: Review Japanese docs in docs/ for prose quality — dearu/desu-masu mixing, ja-technical-writing rule violations, unclear rule descriptions, and MDX component misuse. Invoke when editing or adding docs/ files.
+---
+
+このプロジェクトは Arknights × Emoklore TRPG の日本語ルールブック（Docusaurus サイト）。
+
+## レビュー対象
+
+`docs/` 以下の Markdown / MDX ファイル。
+
+## チェック項目
+
+1. **文体統一**: です/ます調とである調の混在を検出。本プロジェクトはです/ます統一。
+2. **textlint ルール準拠**:
+   - `textlint-rule-preset-ja-technical-writing` の主要ルール（一文の長さ、読点の数、二重否定、etc.）
+   - `textlint-rule-no-mix-dearu-desumasu`
+3. **ルール説明の明確さ**: TRPG ルール文書として、手順・条件・効果が曖昧でないか。
+4. **MDX コンポーネント**: `<Expression>` と `<Memo>` が適切に使われているか。
+
+## 出力フォーマット
+
+指摘箇所を以下の形式で列挙。修正不要なものはスキップ。
+
+```
+[ファイル名:行番号] 問題の種別
+  該当テキスト: 「...」
+  修正案: 「...」
+```
+
+問題なければ「✓ prose 品質 OK」と出力。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true
+  },
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // .tool_input.path // \"\"'); if echo \"$FILE\" | grep -q '/docs/'; then cd \"$CLAUDE_PROJECT_DIR\" && bunx textlint \"$FILE\" 2>&1 | head -20; fi"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

- `context7@claude-plugins-official` を project-scope plugin として有効化（Docusaurus / React ドキュメントのライブ参照）
- `docs/` 以下のファイルを Edit/Write した直後に `textlint` を自動実行する PostToolUse フックを追加
- 日本語 prose レビュー専門サブエージェント `.claude/agents/ja-prose-reviewer.md` を新規作成（です/ます混在・ja-technical-writing ルール・MDX コンポーネント使用確認）

## Test plan

- [ ] `docs/` 内ファイルを編集して textlint フックが自動発火することを確認
- [ ] `context7` ツールが Claude Code セッション内で利用可能になっていることを確認
- [ ] `ja-prose-reviewer` サブエージェントが docs 編集時に呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)