### PR TITLE
chore: Claude Code on the Web のリモート環境セットアップを追加

### DIFF
--- a/.claude/scripts/setup-ccweb.sh
+++ b/.claude/scripts/setup-ccweb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+devbox global add direnv
+eval "$(devbox global shellenv)"
+direnv export bash > "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,10 +14,11 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
-            "command": "direnv export bash > \"$CLAUDE_ENV_FILE\""
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/setup-ccweb.sh\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,33 @@ bun run --bun ncu
 - **Linter/Formatter**: oxlint (with type-check) / oxfmt
 - **デプロイ**: GitHub Pages
 
+### Claude Code on the Web
+
+[claude.ai/code](https://claude.ai/code) でリモート開発する場合のクラウド環境設定例:
+
+**Network access**: Custom
+
+許可ドメイン:
+```text
+*.jetify.com
+*.jetpack.io
++ default list
+```
+
+**Environment variables**:
+```env
+GITHUB_TOKEN=<パブリックリポジトリ読み取り専用PAT>
+NIX_CONFIG='access-token = github.com=$GITHUB_TOKEN'
+```
+
+**Setup script**:
+```bash
+#!/bin/bash
+curl -fsSLvv https://get.jetify.com/devbox | FORCE=1 bash
+```
+
+セッション開始時に `.claude/scripts/setup-ccweb.sh` が自動で devbox / direnv を初期化します。
+
 ### コントリビューション
 
 プルリクエストを歓迎します。大きな変更を行う場合は、まずissueを作成して変更内容について議論してください。


### PR DESCRIPTION
## Summary

- `.claude/scripts/setup-ccweb.sh` を追加: リモートセッション開始時に Nix / devbox / direnv を初期化
- `SessionStart` フックを統合: `startup|resume` のみ対象、リモートはスクリプト経由、ローカルは `direnv export bash` のみ実行
- `README.md` に Claude Code on the Web のクラウド環境設定例を追記

## Test plan

- [ ] ローカルセッション開始時に `direnv export bash` のみ実行されること
- [ ] `CLAUDE_CODE_REMOTE=true` のリモートセッションで `setup-ccweb.sh` が実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)