### PR TITLE
Refine Lighthouse CI assertions with individual Web Vitals metrics

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -17,12 +17,11 @@ module.exports = {
 			},
 		},
 		assert: {
-			// TEMPORARY (Phase 3): ローカル実測値に基づく暫定ベースライン。
-			// 本 PR の趣旨はテスト基盤導入であり、閾値の妥当性検証は scope 外。
-			// 性能はページ毎に特性差が大きいため URL 別に閾値を設定する。
-			// /docs/erosion_check は MDX コンポーネント / コードブロック / admonition が多く 0.6 程度で推移。
-			// TODO(phase4+): observed-floor をベースラインにする現方式は退行検知能力が低いため、
-			// `current - delta` 方式 or 個別 audit (FCP/LCP/TBT/CLS) の数値 assertion へ移行する。
+			// 閾値は lhci collect 実測値 (3 run median) の URL グループ別最悪値から算出:
+			// FCP / LCP / TBT: median_ms * 1.2 の天井値を 50 ms 単位で切り上げ (ms)。
+			// CLS: median + 0.05、下限 0.1 (unitless)。
+			// /docs/ は MDX・コードブロック密度が高く非 docs より遅い傾向がある。
+			// Web Vitals "Good" 境界への引き締めは別 issue で追跡する。
 			assertMatrix: [
 				{
 					matchingUrlPattern: ".*",
@@ -33,20 +32,25 @@ module.exports = {
 						// ランタイム console.error 検出。
 						"errors-in-console": ["error", {}],
 						// 全アセット合計バイト数の budget。Phase 3 導入時の暫定上限値 (5MB)。
-						// Phase 4+ で実測 median を元に調整予定。
 						"total-byte-weight": ["error", { maxNumericValue: 5_000_000 }],
 					},
 				},
 				{
 					matchingUrlPattern: "/docs/",
 					assertions: {
-						"categories:performance": ["error", { minScore: 0.6 }],
+						"first-contentful-paint": ["error", { maxNumericValue: 2050 }],
+						"largest-contentful-paint": ["error", { maxNumericValue: 3050 }],
+						"total-blocking-time": ["error", { maxNumericValue: 350 }],
+						"cumulative-layout-shift": ["error", { maxNumericValue: 0.16 }],
 					},
 				},
 				{
 					matchingUrlPattern: "^(?!.*/docs/).+",
 					assertions: {
-						"categories:performance": ["error", { minScore: 0.7 }],
+						"first-contentful-paint": ["error", { maxNumericValue: 2050 }],
+						"largest-contentful-paint": ["error", { maxNumericValue: 3100 }],
+						"total-blocking-time": ["error", { maxNumericValue: 350 }],
+						"cumulative-layout-shift": ["error", { maxNumericValue: 0.1 }],
 					},
 				},
 			],


### PR DESCRIPTION
## Summary
Replaced aggregate performance score assertions with individual Web Vitals metric assertions in the Lighthouse CI configuration. This provides more granular performance monitoring and better regression detection capabilities.

## Key Changes
- **Assertion Strategy**: Migrated from `categories:performance` score-based assertions to individual audit assertions for:
  - First Contentful Paint (FCP)
  - Largest Contentful Paint (LCP)
  - Total Blocking Time (TBT)
  - Cumulative Layout Shift (CLS)

- **Threshold Calculation**: Updated thresholds based on observed median values from 3-run collections:
  - FCP/LCP/TBT: `median_ms * 1.2` rounded up to nearest 50ms increment
  - CLS: `median + 0.05` with minimum floor of 0.1

- **URL-Specific Thresholds**: Maintained separate assertion groups for `/docs/` and non-docs pages, reflecting their different performance characteristics:
  - `/docs/`: FCP 2050ms, LCP 3050ms, TBT 350ms, CLS 0.16
  - Other pages: FCP 2050ms, LCP 3100ms, TBT 350ms, CLS 0.1

- **Documentation**: Updated comments to clarify the new threshold calculation methodology and note that Web Vitals "Good" boundary alignment is tracked separately.

## Implementation Details
This change improves regression detection by monitoring specific performance metrics rather than relying on aggregate scores, which can mask individual metric degradations. The thresholds are empirically derived from actual site measurements rather than arbitrary targets.

https://claude.ai/code/session_015bwsJvCAZjN3qoztfcDUBo