### PR TITLE
perf(font): システムフォントスタックへ移行（Google Fonts 廃止）

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,7 +4,6 @@
    MCP: Cyberpunk UI + Dark Data Terminal + HUD/Sci-Fi FUI
    ============================================================ */
 
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap");
 
 /* ────────────────────────────────────────────────────────────
    Design Tokens
@@ -54,9 +53,9 @@
 	--ifm-color-emphasis-900: var(--prts-text-primary);
 
 	/* Typography */
-	--ifm-font-family-base: "Noto Sans JP", sans-serif;
-	--ifm-heading-font-family: "JetBrains Mono", monospace;
-	--ifm-font-family-monospace: "JetBrains Mono", "Noto Sans JP", monospace;
+	--ifm-font-family-base: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", "Meiryo", sans-serif;
+	--ifm-heading-font-family: ui-monospace, "SFMono-Regular", "SF Mono", "Cascadia Code", "Cascadia Mono", Consolas, "Liberation Mono", Menlo, Monaco, monospace;
+	--ifm-font-family-monospace: ui-monospace, "SFMono-Regular", "SF Mono", "Cascadia Code", "Cascadia Mono", Consolas, "Liberation Mono", Menlo, Monaco, monospace;
 	--ifm-font-size-base: 100%;
 	--ifm-line-height-base: 1.8;
 	--ifm-heading-line-height: 1.4;
@@ -147,7 +146,7 @@ html {
 body {
 	background-color: transparent;
 	color: var(--prts-text-primary);
-	font-family: "Noto Sans JP", sans-serif;
+	font-family: var(--ifm-font-family-base);
 }
 
 .main-wrapper {
@@ -155,7 +154,7 @@ body {
 }
 
 /* ────────────────────────────────────────────────────────────
-   Typography — Headings use JetBrains Mono
+   Typography — Headings use system monospace
    ──────────────────────────────────────────────────────────── */
 h1,
 h2,
@@ -163,7 +162,7 @@ h3,
 h4,
 h5,
 h6 {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-optical-sizing: auto;
 	color: var(--prts-accent);
 	letter-spacing: 0.04em;
@@ -211,14 +210,14 @@ a:hover {
 }
 
 .navbar__title {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.8rem;
 	letter-spacing: 0.08em;
 	color: var(--prts-accent);
 }
 
 .navbar__link {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.8rem;
 	letter-spacing: 0.05em;
 	text-transform: uppercase;
@@ -294,7 +293,7 @@ a:hover {
 }
 
 .footer__copyright {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.75rem;
 	letter-spacing: 0.05em;
 	color: var(--prts-text-secondary);
@@ -305,7 +304,7 @@ a:hover {
    ──────────────────────────────────────────────────────────── */
 .button {
 	border-radius: 0;
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 	transition: all var(--ifm-transition-fast);
@@ -348,7 +347,7 @@ table {
 table th {
 	background-color: var(--prts-bg-elevated);
 	border-bottom: 2px solid var(--prts-accent);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	letter-spacing: 0.04em;
 	color: var(--prts-accent);
@@ -493,7 +492,7 @@ blockquote p:last-child {
 	background-color: var(--prts-bg-elevated);
 	border: 1px solid var(--prts-accent);
 	border-left: 3px solid var(--prts-accent);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 1.25em;
 	font-weight: bold;
 	margin: 1.5rem 0;

--- a/src/pages/converter.module.css
+++ b/src/pages/converter.module.css
@@ -35,7 +35,7 @@
 }
 
 .label {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.75rem;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
@@ -48,7 +48,7 @@
 	background-color: var(--prts-bg-surface);
 	border: 1px solid var(--prts-border);
 	color: var(--prts-text-primary);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	padding: var(--prts-space-md);
 	resize: vertical;
@@ -71,7 +71,7 @@
 	background-color: var(--prts-bg-surface);
 	border: 1px solid var(--prts-border);
 	color: var(--prts-text-primary);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	padding: var(--prts-space-sm) var(--prts-space-md);
 	appearance: none;
@@ -89,7 +89,7 @@
 .convertButton,
 .copyButton {
 	width: 100%;
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	font-size: 0.9rem;

--- a/src/pages/erosion-calculator.module.css
+++ b/src/pages/erosion-calculator.module.css
@@ -45,7 +45,7 @@
 }
 
 .label {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.75rem;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
@@ -57,7 +57,7 @@
 	background-color: var(--prts-bg-surface);
 	border: 1px solid var(--prts-border);
 	color: var(--prts-text-primary);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	padding: var(--prts-space-sm) var(--prts-space-md);
 	border-radius: 0;
@@ -79,7 +79,7 @@
 .hint {
 	font-size: 0.7rem;
 	color: var(--prts-text-tertiary);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	line-height: 1.4;
 }
 
@@ -98,7 +98,7 @@
 }
 
 .commandLabel {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.75rem;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
@@ -106,7 +106,7 @@
 }
 
 .command {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 1rem;
 	color: var(--prts-accent);
 	background: none;
@@ -116,7 +116,7 @@
 }
 
 .commandMeta {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.8rem;
 	color: var(--prts-text-tertiary);
 }
@@ -130,7 +130,7 @@
 }
 
 .subheading {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.9rem;
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
@@ -139,7 +139,7 @@
 }
 
 .expectedValue {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	color: var(--prts-text-secondary);
 	margin-bottom: var(--prts-space-sm);
@@ -164,7 +164,7 @@
 }
 
 .table th {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.75rem;
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
@@ -189,7 +189,7 @@
 }
 
 .tdCount {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.9rem;
 	padding: var(--prts-space-xs) var(--prts-space-md);
 	color: var(--prts-text-primary);
@@ -198,7 +198,7 @@
 }
 
 .tdProb {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.9rem;
 	padding: var(--prts-space-xs) var(--prts-space-md);
 	color: var(--prts-accent);

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -47,7 +47,7 @@
 }
 
 .systemLabel {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.65rem;
 	letter-spacing: 0.15em;
 	color: var(--prts-text-tertiary);
@@ -58,7 +58,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--prts-space-xs);
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.65rem;
 	letter-spacing: 0.1em;
 	color: var(--prts-success);
@@ -88,7 +88,7 @@
 }
 
 .subtitle {
-	font-family: "JetBrains Mono", monospace;
+	font-family: var(--ifm-heading-font-family);
 	font-size: 0.85rem;
 	color: var(--prts-text-secondary);
 	letter-spacing: 0.05em;


### PR DESCRIPTION
Closes #99

## 概要

Google Fonts CDN からの外部フォント読み込み（Noto Sans JP / JetBrains Mono）を廃止し、OS のシステムフォントスタックへ置き換えました。フォントのネットワーク待ち時間がなくなるため、FCP / LCP が大幅に改善されます。

### フォント対応表

| 役割 | 変更前 | 変更後 |
|------|--------|--------|
| 本文（和文） | Noto Sans JP (Google Fonts) | `"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", "Meiryo", sans-serif` |
| 見出し・UI・コード | JetBrains Mono (Google Fonts) | `ui-monospace, "SFMono-Regular", "SF Mono", "Cascadia Code", "Cascadia Mono", Consolas, …` |

- **macOS/iOS**: Hiragino Sans（ヒラギノ角ゴシック）/ SF Mono
- **Windows**: Yu Gothic UI / Meiryo → Cascadia Code / Consolas
- **Android**: システムの Noto Sans CJK JP（元々プリインストール済み）

## 変更ファイル

- `src/css/custom.css` — `@import` 削除・CSS 変数更新・直書き `font-family` を変数参照へ
- `src/pages/converter.module.css`
- `src/pages/erosion-calculator.module.css`
- `src/pages/index.module.css`

## Lighthouse スコア before / after（中央値、3 回計測）

> `bun run build && bun run test/visual/perf` で計測。環境: WSL2 / Playwright Chromium。

### `/index.html`

| 指標 | Before | After | 変化 |
|------|--------|-------|------|
| Performance | 93 | 98 | **+5** |
| FCP | 2,037 ms | 903 ms | **-55 %** |
| LCP | 2,549 ms | 1,924 ms | **-25 %** |
| TBT | 144 ms | 115 ms | -20 % |
| CLS | 0.039 | 0.039 | — |

### `/converter/index.html`

| 指標 | Before | After | 変化 |
|------|--------|-------|------|
| Performance | 93 | 99 | **+6** |
| FCP | 2,037 ms | 903 ms | **-56 %** |
| LCP | 2,843 ms | 1,922 ms | **-32 %** |
| TBT | 101 ms | 116 ms | +15 ms |
| CLS | 0.001 | 0.000 | 改善 |

### `/erosion-calculator/index.html`

| 指標 | Before | After | 変化 |
|------|--------|-------|------|
| Performance | 94 | 98 | **+4** |
| FCP | 2,041 ms | 903 ms | **-56 %** |
| LCP | 2,535 ms | 1,927 ms | **-24 %** |
| TBT | 118 ms | 125 ms | +7 ms |
| CLS | 0.003 | 0.000 | 改善 |

### `/docs/erosion_check/index.html`

| 指標 | Before | After | 変化 |
|------|--------|-------|------|
| Performance | 74 | 95 | **+21** |
| FCP | 2,050 ms | 904 ms | **-56 %** |
| LCP | 6,561 ms | 2,012 ms | **-69 %** |
| TBT | 66 ms | 122 ms | +56 ms |
| CLS | 0.108 | 0.106 | — |

> `errors-in-console` / CLS の既存失敗はこの変更とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)