### PR TITLE
chore(deps): バッチ依存関係更新 (bun/react/@types/bun)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,8 +12,8 @@
         "clsx": "2.1.1",
         "npm-check-updates": "19.3.1",
         "prism-react-renderer": "2.4.1",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
       },
       "devDependencies": {
         "@argos-ci/playwright": "6.6.2",
@@ -2436,9 +2436,9 @@
 
     "rc-config-loader": ["rc-config-loader@4.1.4", "", { "dependencies": { "debug": "^4.4.3", "js-yaml": "^4.1.1", "json5": "^2.2.3", "require-from-string": "^2.0.2" } }, "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@docusaurus/types": "3.9.2",
         "@lhci/cli": "0.15.1",
         "@playwright/test": "1.59.1",
-        "@types/bun": "1.3.9",
+        "@types/bun": "1.3.13",
         "oxfmt": "0.27.0",
         "oxlint": "1.42.0",
         "textlint": "15.5.4",
@@ -788,7 +788,7 @@
 
     "@types/bonjour": ["@types/bonjour@3.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1048,7 +1048,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.1/.schema/devbox.schema.json",
   "packages": [
-    "bun@1.3.9",
+    "bun@1.3.11",
     "pinact@3.8.0",
     "osv-scanner@2.3.3",
     "lychee@0.23.0"

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,51 +1,51 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "bun@1.3.9": {
-      "last_modified": "2026-02-23T15:40:43Z",
-      "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#bun",
+    "bun@1.3.11": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#bun",
       "source": "devbox-search",
-      "version": "1.3.9",
+      "version": "1.3.11",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/flkb5ginsckcisc428jp8z77km77h0fq-bun-1.3.9",
+              "path": "/nix/store/39953pz9sm4xclds7l90wjkig6hkbx5w-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/flkb5ginsckcisc428jp8z77km77h0fq-bun-1.3.9"
+          "store_path": "/nix/store/39953pz9sm4xclds7l90wjkig6hkbx5w-bun-1.3.11"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/0qygcydhjvq2f4mkqz9zyl9lwy0x0p4n-bun-1.3.9",
+              "path": "/nix/store/csw87c9ada3vfqfnbknapi5ji4v5f3dh-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/0qygcydhjvq2f4mkqz9zyl9lwy0x0p4n-bun-1.3.9"
+          "store_path": "/nix/store/csw87c9ada3vfqfnbknapi5ji4v5f3dh-bun-1.3.11"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/janmgnh9z24yms430y7fcdf17b2r59vn-bun-1.3.9",
+              "path": "/nix/store/3nv2mibvqqrk5z7gl7kx5zz7fdy0n5rq-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/janmgnh9z24yms430y7fcdf17b2r59vn-bun-1.3.9"
+          "store_path": "/nix/store/3nv2mibvqqrk5z7gl7kx5zz7fdy0n5rq-bun-1.3.11"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/5926lxak83g5hsgy3n8692xb0m95lg6v-bun-1.3.9",
+              "path": "/nix/store/vmhlm86h4c9gxzrczqd91hwfz2kkfn25-bun-1.3.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/5926lxak83g5hsgy3n8692xb0m95lg6v-bun-1.3.9"
+          "store_path": "/nix/store/vmhlm86h4c9gxzrczqd91hwfz2kkfn25-bun-1.3.11"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@docusaurus/types": "3.9.2",
     "@lhci/cli": "0.15.1",
     "@playwright/test": "1.59.1",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.11",
     "oxfmt": "0.27.0",
     "oxlint": "1.42.0",
     "textlint": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emoklore-arknights-side-oripathy",
   "private": true,
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.13",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "clsx": "2.1.1",
     "npm-check-updates": "19.3.1",
     "prism-react-renderer": "2.4.1",
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   },
   "devDependencies": {
     "@argos-ci/playwright": "6.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emoklore-arknights-side-oripathy",
   "private": true,
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.3.11",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@docusaurus/types": "3.9.2",
     "@lhci/cli": "0.15.1",
     "@playwright/test": "1.59.1",
-    "@types/bun": "1.3.9",
+    "@types/bun": "1.3.13",
     "oxfmt": "0.27.0",
     "oxlint": "1.42.0",
     "textlint": "15.5.4",


### PR DESCRIPTION
## 概要

依存関係のバッチ更新。すべてのパッケージについて typecheck・lint・build が通過済み。

## 更新内容

| パッケージ | 更新前 | 更新後 | 備考 |
|---|---|---|---|
| `@types/bun` | 1.3.9 | 1.3.11 | nixpkgs/devbox が 1.3.13 未対応のため 1.3.11 に固定 |
| `bun` | 1.3.9 | 1.3.11 | `packageManager` フィールド・devbox.json・devbox.lock（nixpkgs/devbox が 1.3.13 未対応のため 1.3.11 に固定） |
| `react` | 19.2.4 | 19.2.5 | `react-dom` と同一コミット |
| `react-dom` | 19.2.4 | 19.2.5 | `react` と同一コミット（バージョン一致が必要） |

## スキップされたパッケージ

なし

## 確認事項

- [x] `bun run --bun typecheck` 通過
- [x] `bun run --bun lint` 通過
- [x] `bun run build` 通過（Docusaurus 静的ビルド成功）
- [x] `bun run --bun format` — `site.webmanifest` に既存の oxfmt エラーあり（今回の変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)