### PR TITLE
chore(deps): TypeScript を 5.9.3 から 6.0.3 に更新

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "textlint-plugin-mdx": "1.1.0",
         "textlint-rule-no-mix-dearu-desumasu": "6.0.4",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
       },
     },
   },
@@ -2884,7 +2884,7 @@
 
     "typedarray.prototype.slice": ["typedarray.prototype.slice@1.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "math-intrinsics": "^1.1.0", "typed-array-buffer": "^1.0.3", "typed-array-byte-offset": "^1.0.4" } }, "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "textlint-plugin-mdx": "1.1.0",
     "textlint-rule-no-mix-dearu-desumasu": "6.0.4",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "browserslist": {
     "production": [

--- a/src/components/expression.tsx
+++ b/src/components/expression.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
-export default function Expression({ e }) {
+export default function Expression({ e }: { e: React.ReactNode }) {
 	return <p className="c-expression">{e}</p>;
 }

--- a/src/components/memo.tsx
+++ b/src/components/memo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
-export default function Memo({ children }) {
+export default function Memo({ children }: { children: React.ReactNode }) {
 	return <div className="c-memo">{children}</div>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,20 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@docusaurus/tsconfig",
+  // Note: we inline @docusaurus/tsconfig settings instead of extending it to avoid
+  // the deprecated `baseUrl` option that @docusaurus/tsconfig sets (deprecated in TS 6.0).
   "compilerOptions": {
-    // @docusaurus/tsconfig sets baseUrl which is deprecated in TS 6.0.
-    // Remove once upstream (@docusaurus/tsconfig) migrates away from baseUrl.
-    "ignoreDeprecations": "6.0",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true,
     // Explicit bun-types needed for bun:test module resolution in TS 6.0.
     "types": ["bun-types"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,12 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    // @docusaurus/tsconfig sets baseUrl which is deprecated in TS 6.0.
+    // Remove once upstream (@docusaurus/tsconfig) migrates away from baseUrl.
+    "ignoreDeprecations": "6.0",
+    // Explicit bun-types needed for bun:test module resolution in TS 6.0.
+    "types": ["bun-types"]
+  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## 概要

TypeScript を **5.9.3 → 6.0.3** に更新し、TS 6.0 の変更点に対応しました。

## 更新パッケージ

| パッケージ | 変更前 | 変更後 |
|---|---|---|
| `typescript` | 5.9.3 | 6.0.3 |

## プロジェクトコードへの影響

### `tsconfig.json`

`@docusaurus/tsconfig` の extends を廃止し、設定をインライン展開しました。

**背景**: `@docusaurus/tsconfig` は `baseUrl: "."` を設定しているが、この `baseUrl` オプションは TS 6.0 で deprecated になり TS 7.0 で削除予定。`extends` を使う限り子側から `baseUrl` を除去する手段がないため、インライン展開によって `baseUrl` を完全に除去しました。

`paths` は TS 4.1 以降 `baseUrl` なしでも tsconfig ファイルの配置場所からの相対パスで動作するため、`@site/*` エイリアスの解決に影響はありません。

また、TS 6.0 での `bun:test` モジュール解決のため `types: ["bun-types"]` を追加しています。

### `src/components/expression.tsx`

`Expression` コンポーネントの props `e` に `React.ReactNode` 型注釈を追加。TS 6.0 では暗黙的 `any` がエラーになるため対応。

### `src/components/memo.tsx`

`Memo` コンポーネントの props `children` に `React.ReactNode` 型注釈を追加。同上。

## テスト確認

- `bun run --bun typecheck` → エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)