### PR TITLE
fix(fmt): oxfmt が .webmanifest をフォーマット試行してクラッシュする問題を修正

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -4,6 +4,7 @@
   "ignorePatterns": [
     "**/*.css",
     "**/*.json",
+    "**/*.webmanifest",
     "**/*.md",
     "**/*.yml"
   ]


### PR DESCRIPTION
## Summary

- `bun run --bun format` が `static/img/site.webmanifest` のフォーマット時に `DataCloneError` でクラッシュしていた
- `.oxfmtrc.json` の `ignorePatterns` に `**/*.webmanifest` を追加してスキップ対象に

## Test plan

- [x] `bun run --bun format` がエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)