### PR TITLE
chore(deps): actions/deploy-pages を v4.0.5 から v5.0.0 に更新

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## 更新内容

`.github/workflows/deploy-gh-pages.yml` 内の `actions/deploy-pages` を v4.0.5 (`d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`) から v5.0.0 (`cd2ce8fcbc39b97be8ca5fce6e763baed58fa128`) に更新します。

## 主な変更点

- v5.0.0 では Action の実行ランタイムが Node.js 20 から Node.js 24 に更新されました。
- GitHub-hosted runner (`ubuntu-latest`) は Node 24 をサポートしているため、ランナー側の変更は不要です。
- 公開されている入力 (inputs) / 出力 (outputs) のスキーマに破壊的変更は文書化されていません。

## 影響範囲

- workflow ファイル (`.github/workflows/deploy-gh-pages.yml`) のみ。
- アプリケーションコードや Docusaurus ビルド設定への影響なし。

## ローカル検証結果

- `bun install`: 成功
- `bun run build`: 成功 (Docusaurus の static build が問題なく生成されることを確認)

## 残るリスク

- workflow 自体の挙動は GitHub Actions 上で実際に実行されるまで完全には検証できません。
- マージ後、`main` への push によってデプロイワークフローが起動するため、初回の自動デプロイ結果を要確認です。万一失敗した場合は、本コミットを revert することで v4.0.5 に戻せます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9e8j1ACQuEWuh3PqBSK5y)_