### PR TITLE
chore(deps): actions/upload-pages-artifact を v4.0.0 から v5.0.0 に更新

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build
 


### PR DESCRIPTION
## 更新内容

`.github/workflows/deploy-gh-pages.yml` 内の `actions/upload-pages-artifact` を v4.0.0 から v5.0.0 に更新します。

- `actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b` (v4.0.0)
- → `actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9` (v5.0.0)

## 主な変更点

v5.0.0 における upstream の主な変更点は以下のとおりです。

- 内部で利用する `actions/upload-artifact` を v7 に更新。
- 新しい入力 `include-hidden-files` を追加 (デフォルト値: `false`)。

`include-hidden-files` 入力はデフォルトで `false` のため、ドットファイル (`.nojekyll` など) はアーティファクトから除外されます。これは v4.0.0 と同じ既定動作です (v4.0.0 でも `tar --exclude=".[^/]*"` によって同様にドットファイルを除外していたため、ドットファイルの扱いに関する実質的な挙動変化はありません)。

## 影響範囲

- 変更ファイルは `.github/workflows/deploy-gh-pages.yml` のみ。
- アプリケーションコード・ドキュメント・依存パッケージ (`package.json` / `bun.lock`) には変更なし。

## ローカル検証

- `bun install` 成功。
- `bun run build` 成功 (Docusaurus が `build/` に静的ファイルを生成)。
- `build/` 直下に `.nojekyll` (空ファイル) が存在することを確認。v4.0.0 / v5.0.0 いずれも既定では `.nojekyll` をアーティファクトに含めない挙動ですが、本サイトでは Jekyll と競合する `_`-プレフィックス付きディレクトリ・ファイルが `build/` 配下に存在しないため、`.nojekyll` がアーティファクトから除外されても GitHub Pages 配信に影響しないと判断しました (v4.0.0 でも同様の挙動で現状デプロイが成功している点も傍証)。

## 残るリスク

- ワークフロー自体の動作確認は GitHub Actions 実行時にしか行えません。`main` ブランチへのマージで自動デプロイが走るため、マージ後に Pages デプロイが正常に完了することを確認する必要があります。
- 万一 `.nojekyll` の除外による影響が発生した場合 (例: 将来 `_`-プレフィックスのアセットが生成されるようになった場合) は、`include-hidden-files: true` の追加で対処可能です。

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9e8j1ACQuEWuh3PqBSK5y)_