### PR TITLE
Refactor devbox environment setup for remote code execution

### DIFF
--- a/.claude/scripts/setup-ccweb.sh
+++ b/.claude/scripts/setup-ccweb.sh
@@ -3,6 +3,4 @@ set -euo pipefail
 
 source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
-devbox global add direnv
-eval "$(devbox global shellenv)"
-direnv export bash > "$CLAUDE_ENV_FILE"
+( cd "$CLAUDE_PROJECT_DIR" && devbox shellenv --init-hook=false ) > "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "direnv export bash > \"$CLAUDE_ENV_FILE\""
+            "command": "if [ \"$CLAUDE_CODE_REMOTE\" = \"true\" ]; then ( cd \"$CLAUDE_PROJECT_DIR\" && devbox shellenv --init-hook=false ) > \"$CLAUDE_ENV_FILE\"; else direnv export bash > \"$CLAUDE_ENV_FILE\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Updates the Claude environment setup scripts to use `devbox shellenv` directly instead of relying on global `direnv` configuration. This change improves compatibility with remote code execution environments while maintaining backward compatibility for local development.

## Changes
- **setup-ccweb.sh**: Replaced global direnv setup with a direct `devbox shellenv` call that runs in the project directory
  - Removed `devbox global add direnv` and `eval "$(devbox global shellenv)"`
  - Now executes `devbox shellenv --init-hook=false` within `$CLAUDE_PROJECT_DIR`
  
- **settings.json**: Updated the environment hook to conditionally handle remote vs. local execution
  - When `CLAUDE_CODE_REMOTE=true`: uses `devbox shellenv` (for remote environments)
  - Otherwise: falls back to `direnv export bash` (for local development)

## Implementation Details
The `--init-hook=false` flag prevents devbox from executing initialization hooks during the shellenv export, ensuring a clean environment variable export suitable for file-based persistence in `$CLAUDE_ENV_FILE`.

https://claude.ai/code/session_01VDuQsTkfUvjnRA8kf8iNGT