### PR TITLE
chore(deps): bun を 1.3.11 から 1.3.13 に更新

### DIFF
--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -38,6 +38,11 @@ When updating Bun, update all of the following to the same version in a single c
 - `package.json` — `packageManager: "bun@X.Y.Z"`
 - `package.json` — `devDependencies["@types/bun"]: "X.Y.Z"`
 
+**Version alignment with nixhub (required):** `devbox.json` resolves Bun from nixhub, whose available versions lag behind npm. `@types/bun` and `packageManager` come from npm and may offer a newer version than nixhub has. Because all three references must share one version, the target is the **highest version available in both npm and nixhub** — not simply the latest npm/`ncu` version.
+
+1. Before deciding the target version, run `devbox search bun` and confirm the candidate version is listed. If it is missing, step down to the highest version present in both nixhub and npm (verify npm with `bun info bun@X.Y.Z version` / `bun info @types/bun@X.Y.Z version`).
+2. After editing `devbox.json`, run `devbox install` to regenerate `devbox.lock` and confirm the version actually resolves from nixhub. Commit the updated `devbox.lock` together with the other changes.
+
 The `bun-version` input of `oven-sh/setup-bun` does **not** need to be set: the action auto-detects the version from `package.json`'s `packageManager` field when `bun-version` is omitted. Do not add `bun-version` to workflows.
 
 ### `overrides`

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@docusaurus/types": "3.9.2",
         "@lhci/cli": "0.15.1",
         "@playwright/test": "1.59.1",
-        "@types/bun": "1.3.11",
+        "@types/bun": "1.3.13",
         "oxfmt": "0.27.0",
         "oxlint": "1.42.0",
         "textlint": "15.5.4",
@@ -791,7 +791,7 @@
 
     "@types/bonjour": ["@types/bonjour@3.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1053,7 +1053,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.1/.schema/devbox.schema.json",
   "packages": [
-    "bun@1.3.11",
+    "bun@1.3.13",
     "pinact@3.8.0",
     "osv-scanner@2.3.3",
     "lychee@0.23.0"

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,51 +1,51 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "bun@1.3.11": {
-      "last_modified": "2026-04-23T13:07:47Z",
-      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#bun",
+    "bun@1.3.13": {
+      "last_modified": "2026-05-21T08:15:18Z",
+      "resolved": "github:NixOS/nixpkgs/4a29d733e8a7d5b824c3d8c958a946a9867b3eb2#bun",
       "source": "devbox-search",
-      "version": "1.3.11",
+      "version": "1.3.13",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/39953pz9sm4xclds7l90wjkig6hkbx5w-bun-1.3.11",
+              "path": "/nix/store/jgl1hjr0cf6s32jcnqmkp44av4flamap-bun-1.3.13",
               "default": true
             }
           ],
-          "store_path": "/nix/store/39953pz9sm4xclds7l90wjkig6hkbx5w-bun-1.3.11"
+          "store_path": "/nix/store/jgl1hjr0cf6s32jcnqmkp44av4flamap-bun-1.3.13"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/csw87c9ada3vfqfnbknapi5ji4v5f3dh-bun-1.3.11",
+              "path": "/nix/store/ywc7zrq5vr32ashfgc7dp84a2f3rzic6-bun-1.3.13",
               "default": true
             }
           ],
-          "store_path": "/nix/store/csw87c9ada3vfqfnbknapi5ji4v5f3dh-bun-1.3.11"
+          "store_path": "/nix/store/ywc7zrq5vr32ashfgc7dp84a2f3rzic6-bun-1.3.13"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3nv2mibvqqrk5z7gl7kx5zz7fdy0n5rq-bun-1.3.11",
+              "path": "/nix/store/1nphhxm1h3pya9j86kql2gpsvy6nizr4-bun-1.3.13",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3nv2mibvqqrk5z7gl7kx5zz7fdy0n5rq-bun-1.3.11"
+          "store_path": "/nix/store/1nphhxm1h3pya9j86kql2gpsvy6nizr4-bun-1.3.13"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/vmhlm86h4c9gxzrczqd91hwfz2kkfn25-bun-1.3.11",
+              "path": "/nix/store/z1cxjx705fswwjjns0sw2ysbd5jqxfgm-bun-1.3.13",
               "default": true
             }
           ],
-          "store_path": "/nix/store/vmhlm86h4c9gxzrczqd91hwfz2kkfn25-bun-1.3.11"
+          "store_path": "/nix/store/z1cxjx705fswwjjns0sw2ysbd5jqxfgm-bun-1.3.13"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emoklore-arknights-side-oripathy",
   "private": true,
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.13",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
@@ -44,7 +44,7 @@
     "@docusaurus/types": "3.9.2",
     "@lhci/cli": "0.15.1",
     "@playwright/test": "1.59.1",
-    "@types/bun": "1.3.11",
+    "@types/bun": "1.3.13",
     "oxfmt": "0.27.0",
     "oxlint": "1.42.0",
     "textlint": "15.5.4",


### PR DESCRIPTION
## 概要

bun を 1.3.11 から 1.3.13 に更新しました。バージョンを参照する 3 箇所を同一バージョンに揃え、単一コミットにまとめています。

> [!NOTE]
> 当初 1.3.14 を対象にしていましたが、`devbox.json` が参照する nixhub には 1.3.14 が未提供（`devbox search bun` の最新は 1.3.13）でした。3 箇所は同一バージョンに揃える必要があるため、npm・nixhub の両方で利用可能な最高バージョンである **1.3.13** に統一しています。

## 変更内容

| 対象 | 変更前 | 変更後 |
|---|---|---|
| `devbox.json` `packages[].bun` | 1.3.11 | 1.3.13 |
| `package.json` `packageManager` | bun@1.3.11 | bun@1.3.13 |
| `package.json` `devDependencies["@types/bun"]` | 1.3.11 | 1.3.13 |
| `devbox.lock` | （1.3.11 解決） | 1.3.13 解決に再生成 |

`oven-sh/setup-bun` は `bun-version` を省略すると `package.json` の `packageManager` からバージョンを自動検出するため、ワークフローへの `bun-version` 追加は不要です（変更なし）。

## 検証

- `typecheck` / `lint` / `format` / `build` をすべて実行し成功を確認（`build` は `main` 自動デプロイの保護のため必須）。
- `devbox install` で nixhub から bun@1.3.13 が解決できることを確認。

## スキルルールの追記

レビュー指摘を受け、`.claude/skills/update-dependencies/SKILL.md` の bun 特例に「`devbox search` による nixhub とのバージョン整合確認」と「`devbox install` での `devbox.lock` 再生成」を追加しました（別コミット）。